### PR TITLE
Reorder replacements

### DIFF
--- a/contentscript.js
+++ b/contentscript.js
@@ -1,24 +1,53 @@
 var REPLACEMENTS = {
-    'terrorista': 'covarde',
-    'Terrorista': 'Covarde',
-    'terrorismo': 'covardia',
-    'Terrorismo': 'Covardia'
-    
-    'terrorist': 'coward',
-    'Terrorist': 'Coward',
-    'terrorism': 'cowardice',
-    'Terrorism': 'Cowardice',
-    // CN Translation
-    '恐怖': '懦弱'
+    es: {
+        'terrorista': 'cobarde',
+        'Terrorista': 'Cobarde',
+        'terrorismo': 'cobardía',
+        'Terrorismo': 'Cobardía'
+    },
+
+    pt: {
+        'terrorista': 'covarde',
+        'Terrorista': 'Covarde',
+        'terrorismo': 'covardia',
+        'Terrorismo': 'Covardia'
+
+    },
+
+    'default': {
+        'terrorist': 'coward',
+        'Terrorist': 'Coward',
+        'terrorism': 'cowardice',
+        'Terrorism': 'Cowardice',
+        // CN Translation
+        '恐怖': '懦弱'
+    }
 };
 
 var replaceTerror = function(textNode) {
-    var text = textNode.data;
-    for(var before in REPLACEMENTS){
-        if(REPLACEMENTS.hasOwnProperty(before))
-            text = text.replace(new RegExp(before, "g"), REPLACEMENTS[before]);
+    var text = textNode.data,
+        locale = getLocale(),
+        dict = REPLACEMENTS[locale] || REPLACEMENTS.default;
+
+    for (var before in dict) {
+        if (dict.hasOwnProperty(before)) {
+            text = text.replace(new RegExp(before, "g"), dict[before]);
+        }
     }
     textNode.data = text;
+},
+
+getLocale = function () {
+    var locale = document.querySelector('html').getAttribute('lang');
+
+    if (!locale) {
+
+        locale = document.querySelector('meta[http-equiv="Content-Language"') ? 
+                document.querySelector('meta[http-equiv="Content-Language"').getAttribute('content') :
+                'en';
+    }
+
+    return locale.substring(0, 2);
 };
 
 // Only alter text nodes

--- a/contentscript.js
+++ b/contentscript.js
@@ -1,12 +1,13 @@
 var REPLACEMENTS = {
+    'terrorista': 'covarde',
+    'Terrorista': 'Covarde',
+    'terrorismo': 'covardia',
+    'Terrorismo': 'Covardia'
+    
     'terrorist': 'coward',
     'Terrorist': 'Coward',
     'terrorism': 'cowardice',
     'Terrorism': 'Cowardice',
-    'terrorista': 'covarde',
-    'Terrorista': 'Covarde',
-    'terrorismo': 'covardia',
-    'Terrorismo': 'Covardia',
     // CN Translation
     '恐怖': '懦弱'
 };


### PR DESCRIPTION
"terrorist" will be replaced before "terrorista", thus avoiding the translation to be used.
